### PR TITLE
Fix #1: Update bitpacking for correct endianness

### DIFF
--- a/pyflipdot/data.py
+++ b/pyflipdot/data.py
@@ -148,10 +148,16 @@ class ImagePacket(Packet):
         message_image = np.zeros((data_rows, columns), dtype=bool)
         message_image[:rows, :columns] = image
 
-        # Flip image (we send column major, starting 'bottom left')
+        # Flip image vertically
+        # Our image is little-endian (0,0 contains least significant bit)
+        # Packbits expects array to be big-endian
         message_image = np.flipud(message_image)
 
-        # Flatten 'column major', so a whole column of pixels are sent together
+        # Interpret the boolean array as bits in a byte
         # Note: we 'view' as uin8 for numpy versions < 1.10 that don't accept
         # boolean arrays to packbits
-        return bytes(np.packbits(message_image.flatten('F').view(np.uint8)))
+        byte_values = np.packbits(message_image.view(np.uint8), axis=0)
+
+        # Flip vertically so that we send the least significant byte first
+        # Flatten 'column major', so a whole column of pixels are sent together
+        return bytes(np.flipud(byte_values).flatten("F"))

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -21,14 +21,10 @@ class TestPackets(object):
 
     def test_image(self):
         # Send an image as below ('p' indicates byte alignment padding)
-        # (0) | 1, 0 |    | p, p |
-        # (1) | 0, 0 | -> | p, p |
-        # (2) | 0, 0 |    | p, p |
-        # (3) | 0, 0 |    | p, p |
-        # (4)             | p, p |
-        # (5)             | 0, 0 |
-        # (6)             | 0, 0 |
-        # (7)             | 1, 0 |
+        # (0) | 1, 0 |
+        # (1) | 0, 0 | -> [0x01, 0x00]
+        # (2) | 0, 0 |
+        # (3) | 0, 0 |
         image = np.full((3, 2), False)
         image[0, 0] = True
 
@@ -38,26 +34,25 @@ class TestPackets(object):
 
     def test_tall_image(self):
         # Send an image as below ('p' indicates byte alignment padding)
-        # (0)  | 1, 0 |    | p, p |
-        # (1)  | 0, 0 |    | 0, 0 |
-        # (2)  | 0, 0 |    | 0, 0 |
-        # (3)  | 0, 0 |    | 0, 0 |
-        # (4)  | 0, 0 |    | 0, 0 |
-        # (5)  | 0, 0 |    | 0, 0 |
-        # (6)  | 0, 0 |    | 1, 0 |
-        # (7)  | 0, 0 | -> | 0, 0 |
-        # (8)  | 0, 0 |    | 0, 0 |
-        # (9)  | 1, 0 |    | 0, 0 |
-        # (10) | 0, 0 |    | 0, 0 |
-        # (11) | 0, 0 |    | 0, 0 |
-        # (12) | 0, 0 |    | 0, 0 |
-        # (13) | 0, 0 |    | 0, 0 |
-        # (14) | 0, 0 |    | 0, 0 |
-        # (15)             | 1, 0 |
+        # (0)  | 1, 0 |
+        # (1)  | 0, 0 |
+        # (2)  | 0, 0 |
+        # (3)  | 0, 0 |
+        # (4)  | 0, 0 |
+        # (5)  | 0, 0 |
+        # (6)  | 0, 0 |
+        # (7)  | 0, 0 | -> | 0x01, 0x00 | -> [0x01, 0x02, 0x00, 0x00]
+        # (8)  | 0, 0 |    | 0x02, 0x00 |
+        # (9)  | 1, 0 |
+        # (10) | 0, 0 |
+        # (11) | 0, 0 |
+        # (12) | 0, 0 |
+        # (13) | 0, 0 |
+        # (14) | 0, 0 |
         image = np.full((15, 2), False)
-        image[0, 0] = True  # MSbit of MSbyte
-        image[9, 0] = True  # MSbit for LSbyte
+        image[0, 0] = True
+        image[9, 0] = True
 
         packet = ImagePacket(1, image)
         packet_data = packet.get_bytes()
-        assert packet_data == b'\x02110402010000\x03B4'
+        assert packet_data == b'\x02110401020000\x03B4'


### PR DESCRIPTION
It looks like packbits expects big-endian but the Hanover signs work
with little-endian, which was causing problems on signs >8 pixels tall