### PR TITLE
Fix/large signs 2

### DIFF
--- a/pyflipdot/data.py
+++ b/pyflipdot/data.py
@@ -16,23 +16,11 @@ _COMMAND_CODES = {
 
 
 def _to_ascii_hex(value: bytes) -> bytes:
-    def _bytes_to_ascii_hex(val: bytes) -> bytes:
-        return val.hex().upper().encode('ASCII')
-
-    return _bytes_to_ascii_hex(value)
+    return value.hex().upper().encode('ASCII')
 
 
 def _bytes_to_int(data: bytes) -> int:
     return int.from_bytes(data, byteorder='big')
-
-
-def _int_to_bytes(value: int) -> bytes:
-    length = 1
-    while True:
-        try:
-            return value.to_bytes(length, byteorder='big')
-        except OverflowError:
-            length += 1
 
 
 def _closest_larger_multiple(value: int, base: int) -> int:
@@ -131,7 +119,10 @@ class ImagePacket(Packet):
         image_bytes = self.image_to_bytes(image)
 
         # Start with the resolution (image byte count)
-        payload = _to_ascii_hex(_int_to_bytes(len(image_bytes)))
+        # Note: we only ever send a single bytes-worth of info, even if the
+        # resolution is an integer bigger than 255
+        resolution_bytes = (len(image_bytes) & 0xFF).to_bytes(1, byteorder='big')
+        payload = _to_ascii_hex(resolution_bytes)
         # Add the image bytes
         payload += _to_ascii_hex(image_bytes)
 

--- a/pyflipdot/data.py
+++ b/pyflipdot/data.py
@@ -19,14 +19,20 @@ def _to_ascii_hex(value: bytes) -> bytes:
     def _bytes_to_ascii_hex(val: bytes) -> bytes:
         return val.hex().upper().encode('ASCII')
 
-    try:
-        return _bytes_to_ascii_hex(value)
-    except AttributeError:
-        return _bytes_to_ascii_hex(bytes([value]))
+    return _bytes_to_ascii_hex(value)
 
 
 def _bytes_to_int(data: bytes) -> int:
     return int.from_bytes(data, byteorder='big')
+
+
+def _int_to_bytes(value: int) -> bytes:
+    length = 1
+    while True:
+        try:
+            return value.to_bytes(length, byteorder='big')
+        except OverflowError:
+            length += 1
 
 
 def _closest_larger_multiple(value: int, base: int) -> int:
@@ -125,7 +131,7 @@ class ImagePacket(Packet):
         image_bytes = self.image_to_bytes(image)
 
         # Start with the resolution (image byte count)
-        payload = _to_ascii_hex(len(image_bytes))
+        payload = _to_ascii_hex(_int_to_bytes(len(image_bytes)))
         # Add the image bytes
         payload += _to_ascii_hex(image_bytes)
 

--- a/pyflipdot/data.py
+++ b/pyflipdot/data.py
@@ -121,7 +121,8 @@ class ImagePacket(Packet):
         # Start with the resolution (image byte count)
         # Note: we only ever send a single bytes-worth of info, even if the
         # resolution is an integer bigger than 255
-        resolution_bytes = (len(image_bytes) & 0xFF).to_bytes(1, byteorder='big')
+        resolution_bytes = (len(image_bytes) & 0xFF).to_bytes(
+            1, byteorder='big')
         payload = _to_ascii_hex(resolution_bytes)
         # Add the image bytes
         payload += _to_ascii_hex(image_bytes)

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -70,4 +70,3 @@ def test_large_image():
     for val in packet_data[7:-3]:
         assert val.to_bytes(1, byteorder='big') == b'F'
     assert packet_data[-3:] == b'\x033B'
-

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -5,54 +5,69 @@ import numpy as np
 from pyflipdot.data import ImagePacket, Packet
 
 
-class TestPackets(object):
-    def test_no_payload(self):
-        packet = Packet(1, 2)
-        packet_data = packet.get_bytes()
+def test_no_payload():
+    packet = Packet(1, 2)
+    packet_data = packet.get_bytes()
 
-        assert packet_data == b'\x0212\x039A'
+    assert packet_data == b'\x0212\x039A'
 
-    def test_with_payload(self):
-        payload = b'345'
-        packet = Packet(1, 2, payload)
-        packet_data = packet.get_bytes()
 
-        assert packet_data == b'\x0212345\x03FE'
+def test_with_payload():
+    payload = b'345'
+    packet = Packet(1, 2, payload)
+    packet_data = packet.get_bytes()
 
-    def test_image(self):
-        # Send an image as below ('p' indicates byte alignment padding)
-        # (0) | 1, 0 |
-        # (1) | 0, 0 | -> [0x01, 0x00]
-        # (2) | 0, 0 |
-        # (3) | 0, 0 |
-        image = np.full((3, 2), False)
-        image[0, 0] = True
+    assert packet_data == b'\x0212345\x03FE'
 
-        packet = ImagePacket(1, image)
-        packet_data = packet.get_bytes()
-        assert packet_data == b'\x0211020100\x0378'
 
-    def test_tall_image(self):
-        # Send an image as below ('p' indicates byte alignment padding)
-        # (0)  | 1, 0 |
-        # (1)  | 0, 0 |
-        # (2)  | 0, 0 |
-        # (3)  | 0, 0 |
-        # (4)  | 0, 0 |
-        # (5)  | 0, 0 |
-        # (6)  | 0, 0 |
-        # (7)  | 0, 0 | -> | 0x01, 0x00 | -> [0x01, 0x02, 0x00, 0x00]
-        # (8)  | 0, 0 |    | 0x02, 0x00 |
-        # (9)  | 1, 0 |
-        # (10) | 0, 0 |
-        # (11) | 0, 0 |
-        # (12) | 0, 0 |
-        # (13) | 0, 0 |
-        # (14) | 0, 0 |
-        image = np.full((15, 2), False)
-        image[0, 0] = True
-        image[9, 0] = True
+def test_simple_image():
+    # Send an image as below ('p' indicates byte alignment padding)
+    # (0) | 1, 0 |
+    # (1) | 0, 0 | -> [0x01, 0x00]
+    # (2) | 0, 0 |
+    # (3) | 0, 0 |
+    image = np.full((3, 2), False)
+    image[0, 0] = True
 
-        packet = ImagePacket(1, image)
-        packet_data = packet.get_bytes()
-        assert packet_data == b'\x02110401020000\x03B4'
+    packet = ImagePacket(1, image)
+    packet_data = packet.get_bytes()
+    assert packet_data == b'\x0211020100\x0378'
+
+
+def test_tall_image():
+    # Send an image as below ('p' indicates byte alignment padding)
+    # (0)  | 1, 0 |
+    # (1)  | 0, 0 |
+    # (2)  | 0, 0 |
+    # (3)  | 0, 0 |
+    # (4)  | 0, 0 |
+    # (5)  | 0, 0 |
+    # (6)  | 0, 0 |
+    # (7)  | 0, 0 | -> | 0x01, 0x00 | -> [0x01, 0x02, 0x00, 0x00]
+    # (8)  | 0, 0 |    | 0x02, 0x00 |
+    # (9)  | 1, 0 |
+    # (10) | 0, 0 |
+    # (11) | 0, 0 |
+    # (12) | 0, 0 |
+    # (13) | 0, 0 |
+    # (14) | 0, 0 |
+    image = np.full((15, 2), False)
+    image[0, 0] = True
+    image[9, 0] = True
+
+    packet = ImagePacket(1, image)
+    packet_data = packet.get_bytes()
+    assert packet_data == b'\x02110401020000\x03B4'
+
+
+def test_large_image():
+    # Create an image that is 128x32 pixels
+    image = np.full((16, 128), True)
+
+    packet = ImagePacket(1, image)
+    packet_data = packet.get_bytes()
+    assert packet_data[:7] == b'\x02110100'
+    for val in packet_data[7:-3]:
+        assert val.to_bytes(1, byteorder='big') == b'F'
+    assert packet_data[-3:] == b'\x03DA'
+

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -66,8 +66,8 @@ def test_large_image():
 
     packet = ImagePacket(1, image)
     packet_data = packet.get_bytes()
-    assert packet_data[:7] == b'\x02110100'
+    assert packet_data[:5] == b'\x021100'
     for val in packet_data[7:-3]:
         assert val.to_bytes(1, byteorder='big') == b'F'
-    assert packet_data[-3:] == b'\x03DA'
+    assert packet_data[-3:] == b'\x033B'
 


### PR DESCRIPTION
This MR should fix #4

This handles when resolutions are greater than 255 (e.g. a 128x32 sign), which up until now would cause a failure given such numbers cannot fit into a single byte.

This fix replicates the protocol as in https://github.com/ks156/Hanover_Flipdot/blob/master/hanover_flipdot/display.py. i.e. if the resolution is greater than 255 then it is truncated and only the least significant byte is taken.

Because I don't have a 128x32 sign I cannot actually test this. However the linked repo was tested on a 128x16 sign so this truncation seems to be legit